### PR TITLE
Add a dotnet core sdk devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,8 +3,12 @@
     "image": "mcr.microsoft.com/dotnet/core/sdk:3.1",
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
     "workspaceFolder": "/workspace",
-    "extensions": [
-        "ms-dotnettools.csharp",
-        "ms-vscode.vscode-node-azure-pack"
-    ]
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-dotnettools.csharp",
+                "ms-vscode.vscode-node-azure-pack"
+            ]
+        }
+    }
 }

--- a/Adapter/.devcontainer/devcontainer.json
+++ b/Adapter/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+    "name": "C# Dev Container",
+    "image": "mcr.microsoft.com/dotnet/core/sdk:3.1",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+    "workspaceFolder": "/workspace",
+    "extensions": [
+        "ms-dotnettools.csharp",
+        "ms-vscode.vscode-node-azure-pack"
+    ]
+}


### PR DESCRIPTION
Add a devcontainer configuration for .NET Core SDK 3.1

* Create a `.devcontainer` directory and add `devcontainer.json` file.
* Specify the use of the `mcr.microsoft.com/dotnet/core/sdk:3.1` Docker image.
* Include settings for mounting the workspace.
* Install necessary extensions for .NET Core development.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Dedac/csharp-design-patterns-2314072?shareId=d64fbc2a-5164-4e2e-b003-0a4b3ab87a07).